### PR TITLE
FIX: Update CircleCI MySQL image to next-generation image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           - SS_ENVIRONMENT_TYPE=test
           - YUBIAUTH_CLIENTID=12345
           - YUBIAUTH_APIKEY=VGhpc0lzUmVhbGx5QVZhbGlkS2V5
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           - MYSQL_USER=root
           - MYSQL_ROOT_PASSWORD=ubuntu


### PR DESCRIPTION
As per CirleCI's recommendation we should update the MySQL image to use a next-generation image as the old one will be deprecated. Context: https://circleci.com/docs/2.0/circleci-images/